### PR TITLE
manage consent as session state

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,11 +17,15 @@ st.write("""The scope of this survey is to record informative priors of differen
 them in Bayesian impact evaluation to learn more from expensive new programs tested on relatively small samples.""")
 st.write("The research is held on a Colombian Government Program which aimed to increase export in small, medium and large firms.")
 
-#fix the session state
+# Initialize session state
 if 'key' not in st.session_state:
     st.session_state['key'] = 'value'
+    st.session_state['consent'] = False
 
-#insert consent
+# Insert consent
+def add_consent():
+    st.session_state['consent'] = True
+
 placeholder = st.empty()
 with placeholder.container():
     with st.expander("Consent", expanded=True):
@@ -31,7 +35,9 @@ with placeholder.container():
         agree = st.checkbox("I understand and consent.")
         if agree:
             st.markdown("You have consented. Select \"Next\" to start the survey.")
-if st.button('Next'):
+            st.button('Next', on_click=add_consent)
+
+if st.session_state['consent']:
     st.write("Specify your professional category:")
     option = st.selectbox(
         'Select one of the options below:',


### PR DESCRIPTION
Managing consent as a session_state key in Streamlit.

This is needed due to the fact that Streamlit works by [refreshing the code each time something changes](https://docs.streamlit.io/library/get-started/main-concepts#:~:text=a%20Dockerfile.-,Data%20flow,-Streamlit%27s%20architecture%20allows); this causes issues if the choices of the user are not saved in a persistent session state as done in this PR 🚀 